### PR TITLE
update build.sbt so that class path not found errors for dependencies can be avoided.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,3 +40,4 @@ libraryDependencies ++= Seq(
 // assembly config
 assemblyJarName := "GRNBoost.jar"
 test in assembly := {}
+mainClass in assembly := Some("org.aertslab.grnboost.GRNBoost")


### PR DESCRIPTION
update build.sbt so that class path not found errors for dependencies can be avoided.